### PR TITLE
Fix persona session handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,6 +670,9 @@ async function fetchPersonas(){
         if (personaSessions[activePersona]) {
           assistantId = personaSessions[activePersona].assistantId;
           threadId = personaSessions[activePersona].threadId;
+        } else {
+          assistantId = null;
+          threadId = null;
         }
       }
       renderAssistants();
@@ -731,7 +734,9 @@ async function fetchPersonas(){
       e.preventDefault();
       const msg = $("#chatInput").value.trim();
       if (!msg) return;
-      if (!threadId || !assistantId || !activePersona) return toast("No active chat");
+      if (threadId == null || assistantId == null || !activePersona) {
+        return toast("No active chat session. Start or resume a session.");
+      }
     
       const chatBtn = $("#chatForm button");
       addChatMessage('user', msg);
@@ -783,6 +788,9 @@ async function fetchPersonas(){
         if (personaSessions[activePersona]) {
           assistantId = personaSessions[activePersona].assistantId;
           threadId = personaSessions[activePersona].threadId;
+        } else {
+          assistantId = null;
+          threadId = null;
         }
         renderAssistants();
         toast(`Active persona: ${e.target.dataset.name}`);


### PR DESCRIPTION
## Summary
- set assistantId and threadId to null when persona session is missing
- do the same when switching personas via the assistants list
- warn the user when submitting chat with no active session

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be0762ddc83248a774c88d46b1108