### PR TITLE
Fix thread persistence across assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ A simple progressive web app for matching personas and conversing with AI assist
 
 After selecting or creating an assistant you must first run the **Improve** or **Get video suggestions** action. These actions start the conversation and create a single chat thread shared by all personas. Once a thread exists you can freely exchange messages in the chat box. Attempting to chat before running either action will show a "No active chat session" warning.
 
-The conversation and thread IDs remain the same no matter which persona you talk to. Switching assistants only changes the assistant ID that is passed with each message.
+The conversation and thread IDs remain the same no matter which persona you talk to. Both values are stored in `localStorage` so the chat can continue after a refresh. Switching assistants only changes the assistant ID that is passed with each message.

--- a/index.html
+++ b/index.html
@@ -303,16 +303,17 @@
     let selectedPersonas = [];
     const personaAssistants = {};
 
-    // Load conversation_id from query string or localStorage
+    // Load conversation_id and thread_id from query string or localStorage
     (function initConversationId() {
       const params = new URLSearchParams(location.search);
       if (params.has('start_new')) {
         localStorage.removeItem('conversation_id');
+        localStorage.removeItem('thread_id');
       }
-    
+
       const queryId = params.get('conversation_id');
       const storedId = localStorage.getItem('conversation_id');
-    
+
       if (queryId) {
         currentConversationId = queryId;
         localStorage.setItem('conversation_id', currentConversationId);
@@ -321,6 +322,11 @@
       } else {
         // Will get set later after first message
         currentConversationId = null;
+      }
+
+      const storedThread = localStorage.getItem('thread_id');
+      if (storedThread) {
+        threadId = storedThread;
       }
     })();
 
@@ -499,7 +505,12 @@ async function fetchPersonas(){
         const res = await fetch(VIDEO_WEBHOOK, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
-          body: JSON.stringify({ url, persona_id: personaId })
+          body: JSON.stringify({
+            url,
+            persona_id: personaId,
+            conversation_id: currentConversationId,
+            thread_id: threadId
+          })
         });
         if (!res.ok) throw new Error(await res.text());
         const { videos, conversation_id, thread_id, assistant_id } = await res.json();
@@ -516,6 +527,7 @@ async function fetchPersonas(){
         location.hash = "#videoTitle";
       
         threadId    = thread_id;
+        localStorage.setItem('thread_id', threadId);
         assistantId = assistant_id;
         activePersona = personaId;
 
@@ -555,7 +567,12 @@ async function fetchPersonas(){
         const res = await fetch(ASSIST_WEBHOOK, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
-          body: JSON.stringify({ url, persona_id: personaId })
+          body: JSON.stringify({
+            url,
+            persona_id: personaId,
+            conversation_id: currentConversationId,
+            thread_id: threadId
+          })
         });
         if (!res.ok) throw new Error(await res.text());
         const { advice, conversation_id, thread_id, assistant_id } = await res.json();
@@ -569,6 +586,7 @@ async function fetchPersonas(){
         location.hash = "#chatTitle";
 
         threadId    = thread_id;
+        localStorage.setItem('thread_id', threadId);
         assistantId = assistant_id;
         activePersona = personaId;
 


### PR DESCRIPTION
## Summary
- persist thread_id alongside conversation_id so chats can continue
- pass conversation_id and thread_id to improve/video webhooks
- store thread_id in localStorage
- document localStorage behavior in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c023dff6c8324a862e0751756a234