### PR TITLE
Fix assistant polling timestamp check

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,7 +726,7 @@ async function fetchPersonas(){
             return;
           }
     
-          if (data?.answer && new Date(data.created_at) > new Date(afterTimestamp)) {
+          if (data?.answer && new Date(data.created_at) >= new Date(afterTimestamp)) {
             addChatMessage('assistant', data.answer);
             clearInterval(pollInterval);
           }


### PR DESCRIPTION
## Summary
- fix new message check to include equal timestamps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c0688704083248dab6d9f707545f5