### PR TITLE
Fix persona name display during chat interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,6 +376,11 @@
       return { "Authorization": `Basic ${btoa(`user:${pwd}`)}` };
     }
 
+    function getActivePersonaName() {
+      const persona = selectedPersonas.find(p => p.id === activePersona);
+      return persona ? persona.name : 'assistant';
+    }
+
     /* ---------- chat UI ---------- */
     function addChatMessage(sender, text) {
       const label = sender === 'user'
@@ -711,9 +716,9 @@ async function fetchPersonas(){
     let pollInterval = null;
     
     async function pollAssistantReply(conversationId, afterTimestamp) {
-      if (pollInterval) clearInterval(pollInterval);
-    
-      pollInterval = setInterval(async () => {
+        if (pollInterval) clearInterval(pollInterval);
+
+        pollInterval = setInterval(async () => {
         try {
           const res = await fetch(LATEST_REPLY_WEBHOOK, {
             method: 'POST',
@@ -739,10 +744,10 @@ async function fetchPersonas(){
             return;
           }
     
-          if (data?.answer && new Date(data.created_at) >= new Date(afterTimestamp)) {
-            addChatMessage('assistant', data.answer);
-            clearInterval(pollInterval);
-          }
+            if (data?.answer && new Date(data.created_at) >= new Date(afterTimestamp)) {
+              addChatMessage(getActivePersonaName(), data.answer);
+              clearInterval(pollInterval);
+            }
     
         } catch (err) {
           console.error("Polling error:", err);
@@ -765,11 +770,12 @@ async function fetchPersonas(){
       $("#chatInput").value = '';
       setButtonLoading(chatBtn, true, 'Send');
     
-      const thinkingDiv = document.createElement('div');
-      thinkingDiv.style.margin = '0.4rem 0';
-      thinkingDiv.style.opacity = '0.7';
-      thinkingDiv.innerHTML = `<strong>${window.activePersonaName}:</strong> <span class="spinner"></span> Thinking...`;
-      $("#chatBox").appendChild(thinkingDiv);
+        const thinkingDiv = document.createElement('div');
+        thinkingDiv.style.margin = '0.4rem 0';
+        thinkingDiv.style.opacity = '0.7';
+        const personaName = getActivePersonaName();
+        thinkingDiv.innerHTML = `<strong>${personaName}:</strong> <span class="spinner"></span> Thinking...`;
+        $("#chatBox").appendChild(thinkingDiv);
       $("#chatBox").scrollTop = $("#chatBox").scrollHeight;
     
       try {


### PR DESCRIPTION
## Summary
- Ensure chat placeholder uses active persona's name via helper
- Label assistant replies with current persona name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ca64917908324a86ccbea8ce04934