### PR TITLE
Flatten citation result payloads before rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -842,7 +842,15 @@ async function fetchPersonas(){
           body: JSON.stringify({ text: query })
         });
         const data = await res.json();   // [ { result: [...], status: 'ok', ... } ]
-        renderCitations(Array.isArray(data) ? data.flatMap(o => o.result || []) : []);
+        const results = Array.isArray(data)
+          ? data.flatMap(o =>
+              (o.result || []).map(({ score, payload }) => ({
+                score,
+                ...(payload || {})
+              }))
+            )
+          : [];
+        renderCitations(results);
       } catch (err) {
         console.error(err);
         toast('Citation lookup failed');


### PR DESCRIPTION
## Summary
- Flatten citation lookup results by merging `score` and payload fields before rendering

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc76aaa7483249b7da09c6c8e2e0c