### PR TITLE
Display citation results with loading feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,23 +398,38 @@
     }
 
     function renderCitations(list) {
-      if (!Array.isArray(list)) list = [];
       const box = $("#citationResults");
-      box.innerHTML = "";
+      if (!Array.isArray(list) || list.length === 0) {
+        box.innerHTML = '<div class="small">No citations found.</div>';
+        return;
+      }
+
+      box.innerHTML = '';
+      const table = document.createElement('table');
+      table.style.width = '100%';
+      table.style.borderCollapse = 'collapse';
+      table.innerHTML = `
+        <thead>
+          <tr>
+            <th align="left">Title</th>
+            <th align="left">Score</th>
+          </tr>
+        </thead>
+        <tbody></tbody>`;
+      const tbody = table.querySelector('tbody');
+
       list
         .slice()
         .sort((a, b) => b.score - a.score)
-        .forEach(({score, paper_url, paper_title, year, venue, question, answer, specialty}) => {
-          const row = document.createElement("div");
-          row.className = "citation";
-          row.innerHTML =
-            `${paper_title} (${year}). ${venue}. ` +
-            `<a href="${paper_url}" target="_blank">${paper_url}</a> — score: ${score}<br>` +
-            `<strong>Q:</strong> ${question}<br>` +
-            `<strong>A:</strong> ${answer}<br>` +
-            `<em>${(specialty || []).join(", ")}</em>`;
-          box.appendChild(row);
+        .forEach(({score, paper_url, paper_title}) => {
+          const row = document.createElement('tr');
+          row.innerHTML = `
+            <td style="padding:4px 8px;"><a href="${paper_url}" target="_blank">${paper_title}</a></td>
+            <td style="padding:4px 8px;">${score}</td>`;
+          tbody.appendChild(row);
         });
+
+      box.appendChild(table);
     }
 
     /* ---------- chat UI ---------- */
@@ -835,25 +850,28 @@ async function fetchPersonas(){
       if (!raw) return;
       const query = sanitizeText(raw);
       setButtonLoading($("#citationBtn"), true, 'Get Citations');
+      showContentSpinner($("#citationResults"), 'Searching citations...');
       try {
         const res = await fetch(CITATIONS_WEBHOOK, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
           body: JSON.stringify({ text: query })
         });
-        const data = await res.json();   // [ { result: [...], status: 'ok', ... } ]
-        const results = Array.isArray(data)
-          ? data.flatMap(o =>
-              (o.result || []).map(({ score, payload }) => ({
-                score,
-                ...(payload || {})
-              }))
-            )
-          : [];
+        const data = await res.json();   // may be {result:[]} or [{json:{result:[]}}]
+        const arr = Array.isArray(data) ? data : [data];
+        const results = arr.flatMap(o => {
+          const items = o.result || o.json?.result || [];
+          return items.map(({ score, payload }) => ({
+            score,
+            ...(payload || {})
+          }));
+        });
+        console.log('Citation results:', results);
         renderCitations(results);
       } catch (err) {
         console.error(err);
         toast('Citation lookup failed');
+        $("#citationResults").innerHTML = '';
       } finally {
         setButtonLoading($("#citationBtn"), false, 'Get Citations');
       }


### PR DESCRIPTION
## Summary
- parse n8n `get-citations` responses whether array or object
- show a loading spinner while fetching citations
- render citation results in a table with fallback when none found
- handle flows that wrap results under `json.result`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9078c58832489c9e15f3359636a