### PR TITLE
Update persona action button labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,8 +275,8 @@
 
   <div id="urlRow">
     <input id="urlInput"  type="text" placeholder="Paste a web-page URL">
-    <button id="improveSelected">Improve for selected</button>
-    <button id="videoSelected">Videos for selected</button>
+    <button id="improveSelected">Get opinion</button>
+    <button id="videoSelected">Get Video suggestions</button>
   </div>
 
   <h2 id="chatTitle" style="display:none">Chat with this Persona</h2>
@@ -396,6 +396,16 @@
     function getActivePersonaName() {
       const persona = selectedPersonas.find(p => p.id === activePersona);
       return persona ? persona.name : 'assistant';
+    }
+
+    function updateActionButtons() {
+      const btn = $("#improveSelected");
+      if (!btn) return;
+      if (activePersona) {
+        btn.textContent = `Get ${getActivePersonaName()}'s opinion`;
+      } else {
+        btn.textContent = 'Get opinion';
+      }
     }
 
     function sanitizeText(str) {
@@ -767,6 +777,7 @@ async function fetchPersonas(){
         .map(p =>
           `<span class="assistant${p.id===activePersona?' active':''}" data-id="${p.id}" data-name="${p.name}">${p.name}</span>`
         ).join('');
+      updateActionButtons();
     }
 
 
@@ -928,6 +939,8 @@ async function fetchPersonas(){
         toast(`Active persona: ${e.target.dataset.name}`);
       }
     });
+
+    renderAssistants();
 
     /* auto-run if ?url=… */
     window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Replace URL action button labels with clearer wording
- Dynamically include active persona name in opinion button
- Initialize buttons on load and adjust assistant rendering

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc27a9e5c8324a9ae159cee4ef9d7